### PR TITLE
✨ Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   "bugs": {
     "url": "https://github.com/5minds/addict-ioc/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/5minds/addict-ioc"
+  },
   "homepage": "https://github.com/5minds/addict-ioc#readme",
   "devDependencies": {
     "gulptraum": "^1.2.0",


### PR DESCRIPTION
This allows npm to link to the Github project.

You may want to deploy a new version after that.